### PR TITLE
[Docs] Update fetchQuery to include cacheConfig documentation

### DIFF
--- a/docs/Modern-fetchQuery.md
+++ b/docs/Modern-fetchQuery.md
@@ -32,6 +32,7 @@ fetchQuery(environment, query, variables)
 * `environment`: The [Relay Environment](./relay-environment.html)
 * `query`: The `graphql` tagged query. **Note:** `relay-compiler` enforces the query to be named as `<FileName>Query`.
 * `variables`: Object containing set of variables to pass to the GraphQL query, i.e. a mapping from variable name to value.
+* `cacheConfig?`: Optional object containing a set of cache configuration options, i.e. `force: true` requires the fetch to be issued regardless of the state of any configured response cache.
 
 ## Return Value
 


### PR DESCRIPTION
Noticed that `fetchQuery` is missing docs around `cacheConfig`, which is the fourth slot [per the source](https://github.com/facebook/relay/blob/master/packages/relay-runtime/query/fetchQuery.js#L32). 